### PR TITLE
Feature/delete invoice modal keyboard accessible

### DIFF
--- a/src/components/Button.svelte
+++ b/src/components/Button.svelte
@@ -1,7 +1,8 @@
 <script>
   export let type = 'button',
     content,
-    btnClass
+    btnClass,
+    autofocus = false
 </script>
 
 <style lang="scss">
@@ -26,7 +27,7 @@
     background: v(btn-primary-bg);
     transition: background 200ms ease;
 
-    &:hover {
+    &:hover, &:focus {
       background: v(btn-primary-hover-bg);
       transition: background 200ms ease;
     }
@@ -60,7 +61,7 @@
         }
       }
     }
-    &:hover {
+    &:hover, &:focus {
       span {
         background: v(btn-addition-span-hover-bg);
         transition: background 200ms ease;
@@ -73,7 +74,7 @@
     background: v(btn-red-bg);
     transition: color 200ms ease, background 200ms ease;
 
-    &:hover {
+    &:hover, &:focus {
       background: v(btn-red-hover-bg);
     }
   }
@@ -84,7 +85,7 @@
     transition: color 200ms ease, background 200ms ease;
 
 
-    &:hover {
+    &:hover, &:focus {
       background: v(btn-light-hover-bg);
       color: v(btn-light-hover-text);
     }
@@ -96,7 +97,7 @@
     transition: color 200ms ease, background 200ms ease;
 
 
-    &:hover {
+    &:hover, &:focus {
       background: v(btn-dark-hover-bg);
       color: v(btn-dark-hover-text);
     }
@@ -108,7 +109,7 @@
     width: 100%;
     transition: color 200ms ease, background 200ms ease;
 
-    &:hover {
+    &:hover, &:focus {
       background: v(btn-large-hover-bg);
       color: v(btn-large-hover-text);
     }
@@ -116,7 +117,7 @@
 </style>
 
 {#if btnClass === 'addition'}
-  <button {type} on:click class={btnClass}>
+  <button {type} on:click class={btnClass} autofocus>
     <div class="plus-container">
       <span />
       <span />
@@ -124,5 +125,5 @@
     <p>{content}</p>
   </button>
 {:else}
-  <button {type} on:click class={btnClass}>{content}</button>
+  <button {type} on:click class={btnClass} autofocus>{content}</button>
 {/if}

--- a/src/components/Invoice/Invoice.svelte
+++ b/src/components/Invoice/Invoice.svelte
@@ -198,7 +198,7 @@
       </p>
       <div class="buttons">
         <Button content="Cancel" btnClass="light" on:click={cancelDeletion} />
-        <Button content="Delete" btnClass="red" on:click={deleteInvoice} />
+        <Button content="Delete" btnClass="red" autofocus={true} on:click={deleteInvoice} />
       </div>
     </div>
   </div>

--- a/src/components/Invoice/Invoice.svelte
+++ b/src/components/Invoice/Invoice.svelte
@@ -10,7 +10,7 @@
   import Button from '../Button.svelte'
   import invoicesStore from '../../stores/invoicesStore.js'
 
-  import { createEventDispatcher, onDestroy } from 'svelte'
+  import { createEventDispatcher, onMount, onDestroy } from 'svelte'
   const dispatch = createEventDispatcher()
 
   $: invoice = $SelectedInvoice
@@ -42,11 +42,6 @@
     items,
     total,
   }
-
-  onDestroy(() => {
-    SelectedInvoice.clearInvoice()
-  })
-
   let showDeletionConfirmation = false
 
   const showDeleteModal = () => {
@@ -56,7 +51,20 @@
   const cancelDeletion = () => {
     showDeletionConfirmation = !showDeletionConfirmation
   }
-
+  let closeModalEvent
+  onMount(() => {
+    closeModalEvent = window.addEventListener('keydown', (e) => {
+      //Esc for IE/Edgee and Escape for all other browsers
+      //https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key
+      if(e.key === "Esc" || e.key === "Escape") {
+        cancelDeletion()
+      }
+    })
+  });
+  onDestroy(() => {
+    window.removeEventListener("keydown", closeModalEvent)
+    SelectedInvoice.clearInvoice()
+  })
   const deleteInvoice = () => {
     invoicesStore.deleteInvoice(invoiceUid)
     showDeletionConfirmation = !showDeletionConfirmation

--- a/src/components/Invoice/Invoice.svelte
+++ b/src/components/Invoice/Invoice.svelte
@@ -54,7 +54,7 @@
   let closeModalEvent
   onMount(() => {
     closeModalEvent = window.addEventListener('keydown', (e) => {
-      //Esc for IE/Edgee and Escape for all other browsers
+      //Esc for IE/Edge and Escape for all other browsers
       //https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key
       if(e.key === "Esc" || e.key === "Escape") {
         cancelDeletion()


### PR DESCRIPTION
To make this code more re-usable, I would add a prop to SmallModal that has an onEscape custom event. Put the onEscape in the onMount window event listener then we can pass the cancelDeletion function. There is a modal element which you can look into. I checked to make sure my code doesn't create errors in the console but please review it. :)